### PR TITLE
replace rodunj with complate-ast (third take)

### DIFF
--- a/pkg/complate/package.json
+++ b/pkg/complate/package.json
@@ -18,6 +18,6 @@
 		"beatdown": "^1.0.0",
 		"esm": "^3.2.25",
 		"gorgeon": "0.14.0",
-		"rodunj": "^0.10.0"
+		"complate-ast": "https://github.com/larsrh/complate-ast/releases/download/v0.0.8/complate-ast-0.0.8.tgz"
 	}
 }

--- a/src/complate/bundling.js
+++ b/src/complate/bundling.js
@@ -1,7 +1,7 @@
 import { Bundle, Config } from "beatdown";
 import diskless from "beatdown/lib/diskless";
 import { Plugin } from "beatdown/lib/config/plugin";
-import rodunj from "rodunj";
+import { complate } from "complate-ast";
 import acornJSX from "acorn-jsx";
 
 export default class VirtualBundle extends Bundle {
@@ -14,7 +14,7 @@ export default class VirtualBundle extends Bundle {
 			parser: acornJSX()
 		});
 		config.addPlugin(new Plugin("diskless", dl));
-		config.addPlugin(new Plugin("complate-rodunj", rodunj));
+		config.addPlugin(new Plugin("complate-ast", complate, { prefix: "__gorgeon_" }));
 		super(config);
 
 		this._diskless = dl;

--- a/test/test_transform.js
+++ b/test/test_transform.js
@@ -72,7 +72,7 @@ test("complate support", async () => {
 <body>
 	<h1>Hello World</h1>
 <p>lorem ipsum
-dolor sit amet</p><figure><canvas  width="100"  height="100">blank canvas</canvas><figcaption>a blank canvas</figcaption></figure><p>consectetur adipisicing elit,
+dolor sit amet</p><figure><canvas width="100" height="100">blank canvas</canvas><figcaption>a blank canvas</figcaption></figure><p>consectetur adipisicing elit,
 sed do eiusmod tempor</p>
 </body>
 </html>


### PR DESCRIPTION
Just a few tiny code changes, and no measurable impact on the runtime.




<details><summary>Before</summary>

```
$ npm run test:unit
  content blocks
    ✓ rendering
    ✓ default handler
    ✓ decomposition

  complate extension
    ✓ rendering (442ms)

  Markdown extension
    ✓ rendering (38ms)
    ✓ custom heading IDs

  content pages
    ✓ rendering
    ✓ non-blocking layout
    ✓ custom layout
    ✓ slugs
    ✓ custom default format

  web sites
    ✓ page creation
    ✓ transforms' secondary files

  content transformation
    ✓ non-blocking transforms
    ✓ inline blocks
    ✓ complate support


  16 passing (604ms)
```

</details>


<details><summary>After</summary>

```
$ npm run test:unit
  content blocks
    ✓ rendering
    ✓ default handler
    ✓ decomposition

  complate extension
    ✓ rendering (414ms)

  Markdown extension
    ✓ rendering (46ms)
    ✓ custom heading IDs

  content pages
    ✓ rendering
    ✓ non-blocking layout
    ✓ custom layout
    ✓ slugs
    ✓ custom default format

  web sites
    ✓ page creation
    ✓ transforms' secondary files

  content transformation
    ✓ non-blocking transforms
    ✓ inline blocks
    ✓ complate support


  16 passing (581ms)

```

</details>